### PR TITLE
Replace assert.equal with assert.strictEqual

### DIFF
--- a/test/chapterFourFive.js
+++ b/test/chapterFourFive.js
@@ -25,7 +25,7 @@ describe('Mathematical Operations - Test Suite', function(){
 
     var c = a+b;
 
-    assert.equal(c,20);
+    assert.strictEqual(c,20);
 
     setTimeout(done,1000);
 
@@ -36,7 +36,7 @@ describe('Mathematical Operations - Test Suite', function(){
 
     var c = a-b;
 
-    assert.equal(c,0);
+    assert.strictEqual(c,0);
 
     setTimeout(done,2000);
 
@@ -47,7 +47,7 @@ describe('Mathematical Operations - Test Suite', function(){
 
     var c = a*b;
 
-    assert.equal(c,100);
+    assert.strictEqual(c,100);
 
     setTimeout(done,1000);
 
@@ -58,7 +58,7 @@ describe('Mathematical Operations - Test Suite', function(){
       
     var c = a/b;
 
-    assert.equal(c,1);
+    assert.strictEqual(c,1);
 
     setTimeout(done,2000);
 
@@ -71,7 +71,7 @@ describe('Mathematical Operations - Test Suite', function(){
 
     var c = a+b;
 
-    assert.equal(c,20);
+    assert.strictEqual(c,20);
 
     setTimeout(done,1000);
 
@@ -82,7 +82,7 @@ describe('Mathematical Operations - Test Suite', function(){
 
     var c = a-b;
 
-    assert.equal(c,10);
+    assert.strictEqual(c,10);
 
     setTimeout(done,3000);
 
@@ -93,7 +93,7 @@ describe('Mathematical Operations - Test Suite', function(){
 
     var c = a*b;
 
-    assert.equal(c,100);
+    assert.strictEqual(c,100);
 
     setTimeout(done,2000);
 
@@ -104,7 +104,7 @@ describe('Mathematical Operations - Test Suite', function(){
       
     var c = a/b;
 
-    assert.equal(c,1);
+    assert.strictEqual(c,1);
 
     setTimeout(done,1000);
 

--- a/test/chapterSix.js
+++ b/test/chapterSix.js
@@ -14,7 +14,7 @@ describe('Mathematical Operations - Test Suite', function(){
 
     var c = a+b;
 
-    assert.equal(c,20);
+    assert.strictEqual(c,20);
 
     setTimeout(done,1000);
 
@@ -25,7 +25,7 @@ describe('Mathematical Operations - Test Suite', function(){
 
     var c = a-b;
 
-    assert.equal(c,0);
+    assert.strictEqual(c,0);
 
     setTimeout(done,2000);
 
@@ -36,7 +36,7 @@ describe('Mathematical Operations - Test Suite', function(){
 
     var c = a*b;
 
-    assert.equal(c,100);
+    assert.strictEqual(c,100);
 
     setTimeout(done,1000);
 
@@ -47,7 +47,7 @@ describe('Mathematical Operations - Test Suite', function(){
       
     var c = a/b;
 
-    assert.equal(c,1);
+    assert.strictEqual(c,1);
 
     setTimeout(done,2000);
 
@@ -60,7 +60,7 @@ describe('Mathematical Operations - Test Suite', function(){
 
     var c = a+b;
 
-    assert.equal(c,20);
+    assert.strictEqual(c,20);
 
     setTimeout(done,1000);
 
@@ -71,7 +71,7 @@ describe('Mathematical Operations - Test Suite', function(){
 
     var c = a-b;
 
-    assert.equal(c,10);
+    assert.strictEqual(c,10);
 
     setTimeout(done,3000);
 
@@ -82,7 +82,7 @@ describe('Mathematical Operations - Test Suite', function(){
 
     var c = a*b;
 
-    assert.equal(c,100);
+    assert.strictEqual(c,100);
 
     setTimeout(done,2000);
 
@@ -93,7 +93,7 @@ describe('Mathematical Operations - Test Suite', function(){
       
     var c = a/b;
 
-    assert.equal(c,1);
+    assert.strictEqual(c,1);
 
     setTimeout(done,1000);
 

--- a/test/chapterTwo.js
+++ b/test/chapterTwo.js
@@ -18,7 +18,7 @@ describe('Mathematical Operations - Test Suite', function(){
 
     var c = a+b;
 
-    assert.equal(c,20);
+    assert.strictEqual(c,20);
 
   });
 
@@ -29,7 +29,7 @@ describe('Mathematical Operations - Test Suite', function(){
 
     var c = a-b;
 
-    assert.equal(c,0);
+    assert.strictEqual(c,0);
 
 
   });
@@ -41,7 +41,7 @@ describe('Mathematical Operations - Test Suite', function(){
 
     var c = a*b;
 
-    assert.equal(c,100);
+    assert.strictEqual(c,100);
 
 
   });
@@ -53,7 +53,7 @@ describe('Mathematical Operations - Test Suite', function(){
 
     var c = a/b;
 
-    assert.equal(c,0);
+    assert.strictEqual(c,0);
 
 
   });


### PR DESCRIPTION
I made some modifications [Replaced "assert.equal" with "assert.strictEqual"]

"assert.equal" are heavily used. It's a legacy API and deprecated.

https://nodejs.org/api/assert.html#assert_assert_equal_actual_expected_message

It's recommended to replace "assert.equal" with "assert.strictEqual", so that test codes can run on the future versions of Node.js.

Thanks, Giridhar!
